### PR TITLE
Add libzbar and poppler-utils dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,10 @@ ARG RUNTIME_PACKAGES="\
   libmagic-dev \
   libpoppler-cpp-dev \
   libxml2 \
+  libzbar0 \
   optipng \
   pngquant \
+  poppler-utils \
   python3 \
   python3-setuptools \
   qpdf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -38,8 +38,10 @@ ARG RUNTIME_PACKAGES="\
   libmagic-dev \
   libpoppler-cpp-dev \
   libxml2 \
+  libzbar0 \
   optipng \
   pngquant \
+  poppler-utils \
   python3 \
   python3-setuptools \
   redis \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -44,8 +44,10 @@ ARG RUNTIME_PACKAGES="\
   libmagic-dev \
   libpoppler-cpp-dev \
   libxml2 \
+  libzbar0 \
   optipng \
   pngquant \
+  poppler-utils \
   python3 \
   python3-setuptools \
   redis \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -44,6 +44,7 @@ app_setup_block: |
   For convenience this container provides an alias to perform administration management commands. Available administration commands are documented upstream [here](https://paperless-ng.readthedocs.io/en/latest/administration.html) and can be accessed with this container thus: `docker exec -it <container_name> manage <command>`. For example, `docker exec -it paperless manage  document_retagger -tT`.
 # changelog
 changelogs:
+  - { date: "30.04.22:", desc: "Add runtime dependencies lizbar and poppler-utils" }
   - { date: "27.04.22:", desc: "Add build-dependencies for arm32 builds." }
   - { date: "11.04.22:", desc: "Replaced uwsgi with gunicorn due to websocket issues." }
   - { date: "11.03.22:", desc: "Initial Release." }


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-paperless-ngx/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

\closes #10
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Missing packages according to issue #10 added to all three docker files

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
The latest ngx-version needs those dependencies

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local docker builds on my machine are unfortunately terribly slow and are still running. I do not expect things to go wrong when adding two additional packages. So I open the PR while local builds are still running, to close the issue as fast as possibly.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/linuxserver/docker-paperless-ngx/issues/10
https://github.com/paperless-ngx/paperless-ngx/issues/730