### PR TITLE
Fix #12 - added required libxslt1.1 dependency

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -44,6 +44,7 @@ ARG RUNTIME_PACKAGES="\
   libmagic-dev \
   libpoppler-cpp-dev \
   libxml2 \
+  libxslt1.1 \
   libzbar0 \
   optipng \
   pngquant \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -44,6 +44,7 @@ app_setup_block: |
   For convenience this container provides an alias to perform administration management commands. Available administration commands are documented upstream [here](https://paperless-ng.readthedocs.io/en/latest/administration.html) and can be accessed with this container thus: `docker exec -it <container_name> manage <command>`. For example, `docker exec -it paperless manage  document_retagger -tT`.
 # changelog
 changelogs:
+  - { date: "05.05.22:", desc: "Add runtime dependencies libxslt1.1 for armhf" }
   - { date: "30.04.22:", desc: "Add runtime dependencies lizbar and poppler-utils" }
   - { date: "27.04.22:", desc: "Add build-dependencies for arm32 builds." }
   - { date: "11.04.22:", desc: "Replaced uwsgi with gunicorn due to websocket issues." }


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

Closes #12.

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-paperless-ngx/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
The runtime system dependency `libxslt1.1` is added just for `armhf`. 

## Benefits of this PR and context:
As described in #12, without this dependency it's not possible to upload any PDF documents.

## How Has This Been Tested?
Added the dependency on a running instance. Once installed I was able to upload documents.
