### PR TITLE
50-config: remove superfluous '$'

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -3,7 +3,7 @@
 PAPERLESS_REDIS=${REDIS_URL:-redis://localhost:6379}
 
 # remove services unless they're enabled
-if [[ -v "$REDIS_URL" ]]; then
+if [[ -v "REDIS_URL" ]]; then
     rm -rf /etc/services.d/redis
 fi
 


### PR DESCRIPTION
As mentioned in #6 `50-config` contains a superfluous '$' and thus always starts redis even if the env variable is correctly set. This PR fixes that.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-paperless-ngx/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Simple typo fix (see above)
Note: I can rebase the branch, if the merge commit (done via Github) is a problem.

## Benefits of this PR and context:
Relevant issue: #6 
This PR does not start `redis` if not required and thus saves some CPU time and RAM

## How Has This Been Tested?
1. Set "$REDIS_URL" to a URL pointing to a valid redis instance
2. The image does not start redis
3. Profit!

## Source / References:
n/a