### PR TITLE
Fixed container build by specifying the right download url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN \
   fi && \
   curl -o \
     /tmp/paperless.tar.gz -L \
-    "https://github.com/paperless-ngx/paperless-ngx/releases/download/${PAPERLESS_RELEASE}/paperless-${PAPERLESS_RELEASE}.tar.xz" && \
+    "https://github.com/paperless-ngx/paperless-ngx/releases/download/${PAPERLESS_RELEASE}/paperless-ngx-${PAPERLESS_RELEASE}.tar.xz" && \
   tar xf \
   /tmp/paperless.tar.gz -C \
     /app/paperless/ --strip-components=1 && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -90,7 +90,7 @@ RUN \
   fi && \
   curl -o \
     /tmp/paperless.tar.gz -L \
-    "https://github.com/paperless-ngx/paperless-ngx/releases/download/${PAPERLESS_RELEASE}/paperless-${PAPERLESS_RELEASE}.tar.xz" && \
+    "https://github.com/paperless-ngx/paperless-ngx/releases/download/${PAPERLESS_RELEASE}/paperless-ngx-${PAPERLESS_RELEASE}.tar.xz" && \
   tar xf \
   /tmp/paperless.tar.gz -C \
     /app/paperless/ --strip-components=1 && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -97,7 +97,7 @@ RUN \
   fi && \
   curl -o \
     /tmp/paperless.tar.gz -L \
-    "https://github.com/paperless-ngx/paperless-ngx/releases/download/${PAPERLESS_RELEASE}/paperless-${PAPERLESS_RELEASE}.tar.xz" && \
+    "https://github.com/paperless-ngx/paperless-ngx/releases/download/${PAPERLESS_RELEASE}/paperless-ngx-${PAPERLESS_RELEASE}.tar.xz" && \
   tar xf \
   /tmp/paperless.tar.gz -C \
     /app/paperless/ --strip-components=1 && \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/docker-paperless-ngx/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

Building the docker container on amd64 broke with the following error:

> #6 75.78 **** install paperless ****
> #6 76.50   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
> #6 76.50                                  Dload  Upload   Total   Spent    Left  Speed
> 100     9  100     9    0     0     42      0 --:--:-- --:--:-- --:--:--    42
> #6 76.71 tar: This does not look like a tar archive
> #6 76.71
> #6 76.71 gzip: stdin: not in gzip format
> #6 76.72 tar: Child returned status 1
> #6 76.72 tar: Error is not recoverable: exiting now

Reason is a malformed download url.

## Benefits of this PR and context:

Building the container works again

## How Has This Been Tested?

I built a container with the command from the README and the container launches successfully afterwards.

## Source / References:

None
