### PR TITLE
fine tune redis integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **14.05.22:** - Fine tune disabling of redis.
 * **12.05.22:** - Move migrations to after multilangocr mod. Fix disabling of redis. Add missing dep for postgresql.
 * **12.05.22:** - Utilize lsio wheel for pikepdf.
 * **11.05.22:** - Update upstream artifact name and utilize lsio wheels for scipy and scikit-learn.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -44,6 +44,7 @@ app_setup_block: |
   For convenience this container provides an alias to perform administration management commands. Available administration commands are documented upstream [here](https://paperless-ng.readthedocs.io/en/latest/administration.html) and can be accessed with this container thus: `docker exec -it <container_name> manage <command>`. For example, `docker exec -it paperless manage  document_retagger -tT`.
 # changelog
 changelogs:
+  - { date: "14.05.22:", desc: "Fine tune disabling of redis." }
   - { date: "12.05.22:", desc: "Move migrations to after multilangocr mod. Fix disabling of redis. Add missing dep for postgresql." }
   - { date: "12.05.22:", desc: "Utilize lsio wheel for pikepdf." }
   - { date: "11.05.22:", desc: "Update upstream artifact name and utilize lsio wheels for scipy and scikit-learn." }

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -1,9 +1,7 @@
 #!/usr/bin/with-contenv bash
 
-PAPERLESS_REDIS=${REDIS_URL:-redis://localhost:6379}
-
 # remove services unless they're enabled
-if [[ -v "REDIS_URL" ]]; then
+if [ -n "${REDIS_URL}" ]; then
     rm -rf /etc/services.d/redis
 fi
 

--- a/root/etc/cont-init.d/99-migrations
+++ b/root/etc/cont-init.d/99-migrations
@@ -2,6 +2,8 @@
 
 cd /app/paperless || exit
 
+export PAPERLESS_REDIS=${REDIS_URL:-redis://localhost:6379}
+
 s6-setuidgid abc /usr/bin/python3 ./src/manage.py makemigrations
 s6-setuidgid abc /usr/bin/python3 ./src/manage.py migrate
 

--- a/root/etc/services.d/consumer/run
+++ b/root/etc/services.d/consumer/run
@@ -8,6 +8,7 @@ if [[ -z "$REDIS_URL" ]]; then
     sleep 10
 fi
 
+export PAPERLESS_REDIS=${REDIS_URL:-redis://localhost:6379}
+
 exec \
     s6-setuidgid abc python3 manage.py document_consumer
-

--- a/root/etc/services.d/qcluster/run
+++ b/root/etc/services.d/qcluster/run
@@ -8,6 +8,7 @@ if [[ -z "$REDIS_URL" ]]; then
     sleep 10
 fi
 
+export PAPERLESS_REDIS=${REDIS_URL:-redis://localhost:6379}
+
 exec \
     s6-setuidgid abc python3 manage.py qcluster
-


### PR DESCRIPTION
Currently if the `REDIS_URL` variable is set but is blank, redis will still be disabled, leading to no redis. This PR fixes it.

It also attempts to correctly set the `PAPERLESS_REDIS` var for the services